### PR TITLE
Turn up mkdocs strict validation to actually detect issues

### DIFF
--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -8,4 +8,4 @@ See [project README](https://www.github.com/TWiStErRob/net.twisterrob.ghlint) fo
 
 ## Issue Documentation
 
-See [issue documentation](issues/default) for a list of rules and their details.
+See [issue documentation](issues/default/index.md) for a list of rules and their details.

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -8,3 +8,13 @@ markdown_extensions:
   - pymdownx.superfences:
   - toc:
       permalink: true
+
+validation:
+  nav:
+    not_found: warn
+    omitted_files: warn
+    absolute_links: warn
+  links:
+    not_found: warn
+    absolute_links: warn
+    unrecognized_links: warn


### PR DESCRIPTION
```
Run mkdocs build${VERBOSE} --clean --strict
INFO    -  Cleaning site directory
INFO    -  Building documentation to directory: /home/runner/work/net.twisterrob.ghlint/net.twisterrob.ghlint/website/site
INFO    -  Doc file 'index.md' contains an unrecognized relative link 'issues/default', it was left as is. Did you mean 'issues/default/index.md'?
INFO    -  Documentation built in 0.77 seconds
```