### PR TITLE
Fix #136: Model `secrets: inherit`

### DIFF
--- a/.github/workflows/release-prepare-next.yml
+++ b/.github/workflows/release-prepare-next.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: "Checkout ${{ github.ref }} branch in ${{ github.repository }} repository."
         uses: actions/checkout@v4
-  
+
       - name: "Prepare changes."
         id: changes
         run: |
@@ -44,7 +44,7 @@ jobs:
           new_version=$(echo "${old_version}" | awk --field-separator=. '{print $1"."$2"."$3+1"-SNAPSHOT"}')
           sed -re "s/^(project.version=)[0-9]+\.[0-9]+\.[0-9]+\$/\1${new_version}/" -i gradle.properties
           echo "version=${new_version}" >> "${GITHUB_OUTPUT}"
-  
+
       - name: "Prepare git for ${{ env.VERSION }}."
         env:
           VERSION: ${{ steps.changes.outputs.version }}
@@ -58,7 +58,7 @@ jobs:
           git add gradle.properties
           git commit -m "Prepare next development version v${VERSION}"
           git push origin HEAD:"${GIT_BRANCH}" -u -f
-  
+
       - name: "Create Release pull request."
         env:
           GH_TOKEN: ${{ github.token }}

--- a/modules/ghlint-api/src/main/kotlin/net/twisterrob/ghlint/model/Job.kt
+++ b/modules/ghlint-api/src/main/kotlin/net/twisterrob/ghlint/model/Job.kt
@@ -32,8 +32,14 @@ public sealed interface Job : Component {
 
 		public val uses: String
 		public val with: Map<String, String>?
-		public val secrets: Map<String, String>?
+		public val secrets: Secrets?
 
 		public companion object
+	}
+
+	public sealed interface Secrets {
+
+		public interface Inherit : Secrets
+		public interface Explicit : Secrets, Map<String, String>
 	}
 }

--- a/modules/ghlint-docs/src/test/kotlin/net/twisterrob/ghlint/docs/issues/FileLocatorTest.kt
+++ b/modules/ghlint-docs/src/test/kotlin/net/twisterrob/ghlint/docs/issues/FileLocatorTest.kt
@@ -1,7 +1,6 @@
 package net.twisterrob.ghlint.docs.issues
 
 import io.kotest.matchers.paths.aDirectory
-import io.kotest.matchers.paths.aFile
 import io.kotest.matchers.paths.exist
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe

--- a/modules/ghlint-rules/src/main/kotlin/net/twisterrob/ghlint/rules/PreferGitHubTokenRule.kt
+++ b/modules/ghlint-rules/src/main/kotlin/net/twisterrob/ghlint/rules/PreferGitHubTokenRule.kt
@@ -28,7 +28,7 @@ public class PreferGitHubTokenRule : VisitorRule {
 	override fun visitReusableWorkflowCallJob(reporting: Reporting, job: Job.ReusableWorkflowCallJob) {
 		super.visitReusableWorkflowCallJob(reporting, job)
 		job.with.check(reporting, "input", job)
-		job.secrets.check(reporting, "secret", job)
+		(job.secrets as? Job.Secrets.Explicit).check(reporting, "secret", job)
 	}
 
 	override fun visitRunStep(reporting: Reporting, step: Step.Run) {

--- a/modules/ghlint-rules/src/test/kotlin/net/twisterrob/ghlint/rules/PreferGitHubTokenRuleTest.kt
+++ b/modules/ghlint-rules/src/test/kotlin/net/twisterrob/ghlint/rules/PreferGitHubTokenRuleTest.kt
@@ -155,6 +155,19 @@ class PreferGitHubTokenRuleTest {
 		results shouldHave noFindings()
 	}
 
+	@Test fun `passes job secret inherit`() {
+		val results = check<PreferGitHubTokenRule>(
+			"""
+				jobs:
+				  test:
+				    uses: test
+				    secrets: inherit
+			""".trimIndent()
+		)
+
+		results shouldHave noFindings()
+	}
+
 	@Test fun `passes when GITHUB_TOKEN variable is used in job secret`() {
 		val results = check<PreferGitHubTokenRule>(
 			"""

--- a/modules/ghlint-snakeyaml/src/main/kotlin/net/twisterrob/ghlint/model/SnakeJob.kt
+++ b/modules/ghlint-snakeyaml/src/main/kotlin/net/twisterrob/ghlint/model/SnakeJob.kt
@@ -54,6 +54,7 @@ public sealed class SnakeJob protected constructor(
 	}
 
 	public class SnakeReusableWorkflowCallJob internal constructor(
+		private val factory: SnakeComponentFactory,
 		override val parent: Workflow,
 		override val id: String,
 		override val node: MappingNode,
@@ -66,7 +67,18 @@ public sealed class SnakeJob protected constructor(
 		override val with: Map<String, String>?
 			get() = node.getOptional("with")?.run { map.toTextMap() }
 
-		override val secrets: Map<String, String>?
-			get() = node.getOptional("secrets")?.run { map.toTextMap() }
+		override val secrets: Job.Secrets?
+			get() = node.getOptional("secrets")?.let { factory.createSecrets(it) }
 	}
+
+	public class SnakeSecretsExplicit internal constructor(
+		override val node: MappingNode,
+		override val target: Node,
+		private val map: Map<String, String>
+	) : Job.Secrets.Explicit, Map<String, String> by map, HasSnakeNode
+
+	public class SnakeSecretsInherit internal constructor(
+		override val node: MappingNode,
+		override val target: Node,
+	) : Job.Secrets.Inherit, HasSnakeNode
 }


### PR DESCRIPTION
 * Fix #136
 * Fixes https://github.com/TWiStErRob/net.twisterrob.ghlint/security/code-scanning/121
 * Fixes https://github.com/TWiStErRob/net.twisterrob.ghlint/security/code-scanning/87
