### PR TITLE
Replace R8 with canary version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,6 +8,11 @@
 			"description": "Auto-merge own package, because it's still 0.x, which means each release is assumed 'breaking'.",
 			"matchDepNames": ["TWiStErRob/net.twisterrob.ghlint"],
 			"automerge": true
+		},
+		{
+			"description": "Disable R8 upgrades until it's Renovatable: https://issuetracker.google.com/issues/329907500",
+			"matchDepNames": ["com.android.tools:r8"],
+			"enabled": false
 		}
 	]
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ sarif4k = "0.6.0"
 clikt = "4.2.2"
 mordant = "2.4.0"
 buildConfig = "5.3.5"
-r8 = "8.3.37"
+r8 = "8.4.17"
 classgraph = "4.8.168"
 
 junit-jupiter = "5.10.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,6 @@ jsr305 = "3.0.2"
 snakeyaml2 = "2.7"
 sarif4k = "0.6.0"
 clikt = "4.2.2"
-mordant = "2.4.0"
 buildConfig = "5.3.5"
 r8 = "8.4.17"
 classgraph = "4.8.168"
@@ -35,7 +34,6 @@ snakeyaml2 = { module = "org.snakeyaml:snakeyaml-engine", version.ref = "snakeya
 sarif4k = { module = "io.github.detekt.sarif4k:sarif4k", version.ref = "sarif4k" }
 jsonSchema = { module = "dev.harrel:json-schema", version.ref = "jsonSchema" }
 clikt = { module = "com.github.ajalt.clikt:clikt", version.ref = "clikt" }
-mordant = { module = "com.github.ajalt.mordant:mordant", version.ref = "mordant" }
 r8 = { module = "com.android.tools:r8", version.ref = "r8" }
 classgraph = { module = "io.github.classgraph:classgraph", version.ref = "classgraph" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ snakeyaml2 = "2.7"
 sarif4k = "0.6.0"
 clikt = "4.2.2"
 buildConfig = "5.3.5"
-r8 = "8.4.17"
+r8 = "8.4.17-dev"
 classgraph = "4.8.168"
 
 junit-jupiter = "5.10.2"

--- a/modules/ghlint-cli/build.gradle
+++ b/modules/ghlint-cli/build.gradle
@@ -6,8 +6,6 @@ dependencies {
 	api(projects.ghlint)
 	implementation(projects.ghlintApi)
 	api(libs.clikt)
-	// TODEL when https://github.com/ajalt/mordant/issues/160 is released in Clikt.
-	api(libs.mordant)
 }
 
 application {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,9 +23,9 @@ dependencyResolutionManagement {
 	repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
 	repositories {
 		mavenCentral()
-		exclusiveContent { 
-			forRepository { 
-				google()
+		exclusiveContent {
+			forRepository {
+				maven("https://storage.googleapis.com/r8-releases/raw") { name = "R8 releases" }
 			}
 			filter {
 				includeModule("com.android.tools", "r8")


### PR DESCRIPTION
 * See https://issuetracker.google.com/issues/329678175#comment2
 * Triggered https://issuetracker.google.com/issues/329907500
 * Reverts some changes in https://github.com/TWiStErRob/net.twisterrob.ghlint/pull/125