### PR TITLE
Enable parallel test execution

### DIFF
--- a/config/junit/junit-platform.properties
+++ b/config/junit/junit-platform.properties
@@ -1,0 +1,5 @@
+junit.jupiter.testinstance.lifecycle.default=per_method
+junit.jupiter.execution.parallel.config.strategy=dynamic
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=concurrent
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/gradle/plugins/src/main/kotlin/net/twisterrob/ghlint/build/testing.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/net/twisterrob/ghlint/build/testing.gradle.kts
@@ -2,6 +2,7 @@ package net.twisterrob.ghlint.build
 
 import net.twisterrob.ghlint.build.dsl.isCI
 import net.twisterrob.ghlint.build.dsl.libs
+import java.util.Properties
 
 plugins {
 	id("org.gradle.java")
@@ -21,6 +22,12 @@ testing.suites.withType<JvmTestSuite>().configureEach {
 				languageVersion.set(JavaLanguageVersion.of(libs.versions.java.toolchainTest.get()))
 			})
 			ignoreFailures = isCI.get()
+			systemProperties(
+				rootProject.file("config/junit/junit-platform.properties")
+					.reader()
+					.use { Properties().apply { load(it) } }
+					.mapKeys { (k, _) -> k.toString() }
+			)
 		}
 	}
 }


### PR DESCRIPTION
`gradlew cleanTest test --no-build-cache` went from 13 seconds to 10 seconds on my local.
`gradlew clean build --no-build-cache` went from 23 seconds to 17 seconds on my local.