### PR TITLE
Fix Java 21+ red wall of text in unit tests with mock()

### DIFF
--- a/gradle/plugins/src/main/kotlin/net/twisterrob/ghlint/build/testing.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/net/twisterrob/ghlint/build/testing.gradle.kts
@@ -28,6 +28,9 @@ testing.suites.withType<JvmTestSuite>().configureEach {
 					.use { Properties().apply { load(it) } }
 					.mapKeys { (k, _) -> k.toString() }
 			)
+			if (javaVersion.isCompatibleWith(JavaVersion.VERSION_21)) {
+				jvmArgs("-XX:+EnableDynamicAgentLoading")
+			}
 		}
 	}
 }

--- a/gradle/plugins/src/main/kotlin/net/twisterrob/ghlint/build/testing.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/net/twisterrob/ghlint/build/testing.gradle.kts
@@ -29,6 +29,7 @@ testing.suites.withType<JvmTestSuite>().configureEach {
 					.mapKeys { (k, _) -> k.toString() }
 			)
 			if (javaVersion.isCompatibleWith(JavaVersion.VERSION_21)) {
+				// https://github.com/mockito/mockito/issues/3037#issuecomment-1588199599
 				jvmArgs("-XX:+EnableDynamicAgentLoading")
 			}
 		}


### PR DESCRIPTION
This triggers when running a test with a `mock()` in IDEA:

```
> Task :ghlint-api:testClasses UP-TO-DATE
WARNING: A Java agent has been loaded dynamically (Z:\caches\gradle\caches\modules-2\files-2.1\net.bytebuddy\byte-buddy-agent\1.14.9\dfb8707031008535048bad2b69735f46d0b6c5e5\byte-buddy-agent-1.14.9.jar)
WARNING: If a serviceability tool is in use, please run with -XX:+EnableDynamicAgentLoading to hide this warning
WARNING: If a serviceability tool is not in use, please run with -Djdk.instrument.traceUsage for more information
WARNING: Dynamic loading of agents will be disallowed by default in a future release
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended

> Task :ghlint-api:test
```

 * See https://github.com/mockito/mockito/issues/3037 for more info.