### PR TITLE
Optimize position calculation to speed up tests

### DIFF
--- a/modules/ghlint-testing/src/main/kotlin/net/twisterrob/ghlint/testing/locationOfNth.kt
+++ b/modules/ghlint-testing/src/main/kotlin/net/twisterrob/ghlint/testing/locationOfNth.kt
@@ -49,7 +49,7 @@ private fun String.indexOfNth(string: String, occurrence: Int): Int =
 
 private fun String.positionOf(index: Int): Position {
 	val line = this.substring(0, index).count { '\n' == it }
-	val before = this.lines().take(line).sumOf { it.length + 1 }
+	val before = this.lineSequence().take(line).sumOf { it.length + 1 }
 	return Position(
 		LineNumber(line + 1),
 		ColumnNumber(index - before + 1),


### PR DESCRIPTION
As an attempt to fix

![image](https://github.com/user-attachments/assets/06aef54c-866f-44df-95e8-d4b21debc266)

```
reports when myriad of ids are similar() (net.twisterrob.ghlint.rules.DuplicateStepIdRuleTest$Workflows) failed
results/modules/ghlint-rules/build/test-results/test/TEST-net.twisterrob.ghlint.rules.DuplicateStepIdRuleTest$Workflows.xml [took 5s]
java.util.concurrent.TimeoutException: reports when myriad of ids are similar() timed out after 5 seconds
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.tryRemoveAndExec(ForkJoinPool.java:1351)
	at java.base/java.util.concurrent.ForkJoinTask.awaitDone(ForkJoinTask.java:422)
	at java.base/java.util.concurrent.ForkJoinTask.join(ForkJoinTask.java:651)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.tryRemoveAndExec(ForkJoinPool.java:1351)
	at java.base/java.util.concurrent.ForkJoinTask.awaitDone(ForkJoinTask.java:422)
	at java.base/java.util.concurrent.ForkJoinTask.join(ForkJoinTask.java:651)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1312)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1843)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1808)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188)
Caused by: org.junit.jupiter.api.AssertTimeoutPreemptively$ExecutionTimeoutException: Execution timed out in thread junit-timeout-thread-72
	at app//kotlin.text.StringsKt__StringsKt.findAnyOf$StringsKt__StringsKt(Strings.kt:1637)
	at app//kotlin.text.StringsKt__StringsKt.access$findAnyOf(Strings.kt:1)
	at app//kotlin.text.StringsKt__StringsKt$rangesDelimitedBy$2.invoke(Strings.kt:1278)
	at app//kotlin.text.StringsKt__StringsKt$rangesDelimitedBy$2.invoke(Strings.kt:1278)
	at app//kotlin.text.DelimitedRangesSequence$iterator$1.calcNext(Strings.kt:1206)
	at app//kotlin.text.DelimitedRangesSequence$iterator$1.hasNext(Strings.kt:1235)
	at app//kotlin.sequences.TransformingSequence$iterator$1.hasNext(Sequences.kt:214)
	at app//kotlin.sequences.SequencesKt___SequencesKt.toList(_Sequences.kt:820)
	at app//kotlin.text.StringsKt__StringsKt.lines(Strings.kt:1413)
	at app//net.twisterrob.ghlint.testing.LocationOfNthKt.positionOf(locationOfNth.kt:52)
	at app//net.twisterrob.ghlint.testing.LocationOfNthKt.locationOfNth-2A2NEhU(locationOfNth.kt:40)
	at app//net.twisterrob.ghlint.testing.LocationOfNthKt.locationOfNth(locationOfNth.kt:30)
	at app//net.twisterrob.ghlint.testing.LocationOfNthKt.locationOfNth$default(locationOfNth.kt:29)
	at app//net.twisterrob.ghlint.rules.DuplicateStepIdRuleTest$Workflows.reports when myriad of ids are similar(DuplicateStepIdRuleTest.kt:258)
	at java.base@21.0.4/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base@21.0.4/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base@21.0.4/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base@21.0.4/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base@21.0.4/java.lang.Thread.run(Thread.java:1583)
```
