### PR TITLE
Attempt to fix flaky CapturedOutputTest tests

### DIFF
--- a/modules/test-helpers/src/test/kotlin/net/twisterrob/ghlint/test/CapturedOutputTest.kt
+++ b/modules/test-helpers/src/test/kotlin/net/twisterrob/ghlint/test/CapturedOutputTest.kt
@@ -5,6 +5,8 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.beEmpty
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import org.junit.jupiter.api.parallel.ResourceAccessMode
 import org.junit.jupiter.api.parallel.ResourceLock
 import org.junit.jupiter.api.parallel.Resources
@@ -15,6 +17,8 @@ import org.junit.jupiter.api.parallel.Resources
 )
 // Capturing system streams is not thread-safe.
 // Even though we could declare resource locks for each test, it's not good enough.
+// Each test will be affected by both stdout and stderr, so they cannot be executed in parallel in any way.
+@Execution(ExecutionMode.SAME_THREAD)
 @ResourceLock(value = Resources.SYSTEM_OUT, mode = ResourceAccessMode.READ_WRITE)
 @ResourceLock(value = Resources.SYSTEM_ERR, mode = ResourceAccessMode.READ_WRITE)
 class CapturedOutputTest {

--- a/modules/test-helpers/src/test/kotlin/net/twisterrob/ghlint/test/CapturedOutputTest.kt
+++ b/modules/test-helpers/src/test/kotlin/net/twisterrob/ghlint/test/CapturedOutputTest.kt
@@ -9,7 +9,10 @@ import org.junit.jupiter.api.parallel.ResourceAccessMode
 import org.junit.jupiter.api.parallel.ResourceLock
 import org.junit.jupiter.api.parallel.Resources
 
-@Suppress("detekt.ForbiddenMethodCall") // Testing console output.
+@Suppress(
+	"detekt.ForbiddenMethodCall", // Testing console output.
+	"ReplaceJavaStaticMethodWithKotlinAnalog", // Be explicit for readability.
+)
 class CapturedOutputTest {
 
 	/**
@@ -22,7 +25,7 @@ class CapturedOutputTest {
 		@ResourceLock(value = Resources.SYSTEM_ERR, mode = ResourceAccessMode.READ_WRITE)
 		fun exampleUsage() {
 			val captured = captureSystemStreams {
-				print("Hello")
+				System.out.print("Hello")
 				System.err.print("World")
 				42
 			}
@@ -36,9 +39,9 @@ class CapturedOutputTest {
 		@ResourceLock(value = Resources.SYSTEM_ERR, mode = ResourceAccessMode.READ_WRITE)
 		fun `captures interleaved multiline output`() {
 			val captured = captureSystemStreams {
-				println("Hello")
+				System.out.println("Hello")
 				System.err.println("World")
-				println("GH-Lint")
+				System.out.println("GH-Lint")
 				System.err.println("Testing")
 				42
 			}
@@ -78,7 +81,7 @@ class CapturedOutputTest {
 		@ResourceLock(value = Resources.SYSTEM_OUT, mode = ResourceAccessMode.READ_WRITE)
 		fun `captures single line Unit`() {
 			val captured = captureSystemOutOnly {
-				println("Hello")
+				System.out.println("Hello")
 			}
 			captured shouldBe "Hello${System.lineSeparator()}"
 		}
@@ -87,9 +90,9 @@ class CapturedOutputTest {
 		@ResourceLock(value = Resources.SYSTEM_OUT, mode = ResourceAccessMode.READ_WRITE)
 		fun `captures many lines Unit`() {
 			val captured = captureSystemOutOnly {
-				println("Hello")
-				println("GH-Lint")
-				println("Testing")
+				System.out.println("Hello")
+				System.out.println("GH-Lint")
+				System.out.println("Testing")
 			}
 			captured shouldBe """
 				Hello
@@ -103,7 +106,7 @@ class CapturedOutputTest {
 		@ResourceLock(value = Resources.SYSTEM_OUT, mode = ResourceAccessMode.READ_WRITE)
 		fun `captures single line R`() {
 			val captured = captureSystemOut {
-				println("Hello")
+				System.out.println("Hello")
 				"42"
 			}
 			captured.result shouldBe "42"
@@ -115,9 +118,9 @@ class CapturedOutputTest {
 		@ResourceLock(value = Resources.SYSTEM_OUT, mode = ResourceAccessMode.READ_WRITE)
 		fun `captures many lines R`() {
 			val captured = captureSystemOut {
-				println("Hello")
-				println("GH-Lint")
-				println("Testing")
+				System.out.println("Hello")
+				System.out.println("GH-Lint")
+				System.out.println("Testing")
 				"42"
 			}
 			captured.result shouldBe "42"
@@ -221,7 +224,7 @@ class CapturedOutputTest {
 		@ResourceLock(value = Resources.SYSTEM_ERR, mode = ResourceAccessMode.READ_WRITE)
 		fun `ignores output stream`() {
 			val captured = captureSystemErr {
-				println("Hello")
+				System.out.println("Hello")
 				42
 			}
 			captured.result shouldBe 42

--- a/modules/test-helpers/src/test/kotlin/net/twisterrob/ghlint/test/CapturedOutputTest.kt
+++ b/modules/test-helpers/src/test/kotlin/net/twisterrob/ghlint/test/CapturedOutputTest.kt
@@ -13,6 +13,10 @@ import org.junit.jupiter.api.parallel.Resources
 	"detekt.ForbiddenMethodCall", // Testing console output.
 	"ReplaceJavaStaticMethodWithKotlinAnalog", // Be explicit for readability.
 )
+// Capturing system streams is not thread-safe.
+// Even though we could declare resource locks for each test, it's not good enough.
+@ResourceLock(value = Resources.SYSTEM_OUT, mode = ResourceAccessMode.READ_WRITE)
+@ResourceLock(value = Resources.SYSTEM_ERR, mode = ResourceAccessMode.READ_WRITE)
 class CapturedOutputTest {
 
 	/**
@@ -21,8 +25,6 @@ class CapturedOutputTest {
 	@Nested
 	inner class Streams {
 		@Test
-		@ResourceLock(value = Resources.SYSTEM_OUT, mode = ResourceAccessMode.READ_WRITE)
-		@ResourceLock(value = Resources.SYSTEM_ERR, mode = ResourceAccessMode.READ_WRITE)
 		fun exampleUsage() {
 			val captured = captureSystemStreams {
 				System.out.print("Hello")
@@ -35,8 +37,6 @@ class CapturedOutputTest {
 		}
 
 		@Test
-		@ResourceLock(value = Resources.SYSTEM_OUT, mode = ResourceAccessMode.READ_WRITE)
-		@ResourceLock(value = Resources.SYSTEM_ERR, mode = ResourceAccessMode.READ_WRITE)
 		fun `captures interleaved multiline output`() {
 			val captured = captureSystemStreams {
 				System.out.println("Hello")
@@ -66,7 +66,6 @@ class CapturedOutputTest {
 	@Nested
 	inner class Output {
 		@Test
-		@ResourceLock(value = Resources.SYSTEM_OUT, mode = ResourceAccessMode.READ_WRITE)
 		fun exampleUsage() {
 			val captured = captureSystemOut {
 				print("Hello")
@@ -78,7 +77,6 @@ class CapturedOutputTest {
 		}
 
 		@Test
-		@ResourceLock(value = Resources.SYSTEM_OUT, mode = ResourceAccessMode.READ_WRITE)
 		fun `captures single line Unit`() {
 			val captured = captureSystemOutOnly {
 				System.out.println("Hello")
@@ -87,7 +85,6 @@ class CapturedOutputTest {
 		}
 
 		@Test
-		@ResourceLock(value = Resources.SYSTEM_OUT, mode = ResourceAccessMode.READ_WRITE)
 		fun `captures many lines Unit`() {
 			val captured = captureSystemOutOnly {
 				System.out.println("Hello")
@@ -103,7 +100,6 @@ class CapturedOutputTest {
 		}
 
 		@Test
-		@ResourceLock(value = Resources.SYSTEM_OUT, mode = ResourceAccessMode.READ_WRITE)
 		fun `captures single line R`() {
 			val captured = captureSystemOut {
 				System.out.println("Hello")
@@ -115,7 +111,6 @@ class CapturedOutputTest {
 		}
 
 		@Test
-		@ResourceLock(value = Resources.SYSTEM_OUT, mode = ResourceAccessMode.READ_WRITE)
 		fun `captures many lines R`() {
 			val captured = captureSystemOut {
 				System.out.println("Hello")
@@ -134,7 +129,6 @@ class CapturedOutputTest {
 		}
 
 		@Test
-		@ResourceLock(value = Resources.SYSTEM_OUT, mode = ResourceAccessMode.READ_WRITE)
 		fun `ignores error stream`() {
 			val captured = captureSystemOut {
 				System.err.println("Hello")
@@ -153,7 +147,6 @@ class CapturedOutputTest {
 	@Nested
 	inner class Error {
 		@Test
-		@ResourceLock(value = Resources.SYSTEM_ERR, mode = ResourceAccessMode.READ_WRITE)
 		fun exampleUsage() {
 			val captured = captureSystemErr {
 				System.err.print("Hello")
@@ -165,7 +158,6 @@ class CapturedOutputTest {
 		}
 
 		@Test
-		@ResourceLock(value = Resources.SYSTEM_ERR, mode = ResourceAccessMode.READ_WRITE)
 		fun `captures single line Unit`() {
 			val captured = captureSystemErrOnly {
 				System.err.println("Hello")
@@ -174,7 +166,6 @@ class CapturedOutputTest {
 		}
 
 		@Test
-		@ResourceLock(value = Resources.SYSTEM_ERR, mode = ResourceAccessMode.READ_WRITE)
 		fun `captures many lines Unit`() {
 			val captured = captureSystemErrOnly {
 				System.err.println("Hello")
@@ -190,7 +181,6 @@ class CapturedOutputTest {
 		}
 
 		@Test
-		@ResourceLock(value = Resources.SYSTEM_ERR, mode = ResourceAccessMode.READ_WRITE)
 		fun `captures single line R`() {
 			val captured = captureSystemErr {
 				System.err.println("Hello")
@@ -202,7 +192,6 @@ class CapturedOutputTest {
 		}
 
 		@Test
-		@ResourceLock(value = Resources.SYSTEM_ERR, mode = ResourceAccessMode.READ_WRITE)
 		fun `captures many lines R`() {
 			val captured = captureSystemErr {
 				System.err.println("Hello")
@@ -221,7 +210,6 @@ class CapturedOutputTest {
 		}
 
 		@Test
-		@ResourceLock(value = Resources.SYSTEM_ERR, mode = ResourceAccessMode.READ_WRITE)
 		fun `ignores output stream`() {
 			val captured = captureSystemErr {
 				System.out.println("Hello")


### PR DESCRIPTION
mkdocs-material (i.e. unrelated PR) failed
![image](https://github.com/user-attachments/assets/7e987641-f0ac-495f-8f7e-9eaa5c95512e)

https://github.com/TWiStErRob/net.twisterrob.ghlint/pull/445/checks?check_run_id=33507438116