### PR TITLE
Add Java 26 to the CI matrix

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -169,6 +169,7 @@ jobs:
           - 17
           - 21
           - 25
+          - 26
 
     runs-on: ubuntu-24.04
     defaults:


### PR DESCRIPTION
## Summary

- add Java 26 to the CLI execution matrix
- retain Java 17, 21, and 25 coverage for all supported LTS releases
- keep the matrix covering the latest Java feature release

## Impact

CI will verify that the packaged CLI runs on every supported Java LTS release and the latest Java release.

## Validation

Not run locally; delegated to CI as requested.
